### PR TITLE
Minor cleanup of manifests and build scripts of IRB 120 and 4400 pkgs

### DIFF
--- a/abb_irb120_support/CMakeLists.txt
+++ b/abb_irb120_support/CMakeLists.txt
@@ -8,10 +8,13 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml)
+  roslaunch_add_file_check(tests/roslaunch_test.xml
+    DEPENDENCIES
+      # not nice, but industrial_robot_client doesn't prefix its targets
+      joint_trajectory_action
+      abb_driver_robot_state
+      abb_driver_motion_download_interface)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/abb_irb120_support/package.xml
+++ b/abb_irb120_support/package.xml
@@ -1,20 +1,23 @@
+<?xml version="1.0"?>
 <package>
   <name>abb_irb120_support</name>
-  <version>0.2.0</version>
+  <version>0.1.0</version>
   <description>
     <p>
       ROS-Industrial support for the ABB IRB 120 (and variants).
     </p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for ABB IRB 120 manipulators. This includes the base model (120) and the 120T.
+      for ABB IRB 120 manipulators. This includes the base model (120) and
+      the 120T.
     </p>
     <p>
-      Joint limits and max joint velocities are based on the information in the 
-      <a href="http://new.abb.com/products/robotics/industrial-robots/irb-120/irb-120-data">ABB 
-      IRB 120 technical data sheet</a> (Version: ROB0149EN_D, May 2012). All URDFs / XACROs are 
-      based on the default motion and joint velocity limits, unless noted otherwise (ie: no 
-      support for high speed joints, extended / limited motion ranges or other options).
+      Joint limits and max joint velocities are based on the information in the
+      <a href="http://new.abb.com/products/robotics/industrial-robots/irb-120/irb-120-data">
+      ABB IRB 120 technical data sheet</a> (Version: ROB0149EN_D, May 2012).
+      All urdfs / xacros are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
     </p>
     <p>
       Before using any of the configuration files and / or meshes included
@@ -24,18 +27,25 @@
   </description>
   <author email="culletom@tcd.ie">Mark Culleton (Trinity College Dublin)</author>
   <maintainer email="culletom@tcd.ie">Mark Culleton (Trinity College Dublin)</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (SwRI)</maintainer>
   <license>Apache2</license>
 
-  <url type="website">http://wiki.ros.org/abb</url>
+  <url type="website">http://ros.org/wiki/abb_irb120_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb_experimental/issues</url>
   <url type="repository">https://github.com/ros-industrial/abb_experimental</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roslaunch</build_depend>
+  <build_depend version_gte="1.9.55">roslaunch</build_depend>
 
   <run_depend>abb_driver</run_depend>
+  <run_depend>abb_resources</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>rviz</run_depend>
+  <run_depend>xacro</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/abb_irb120_support/package.xml
+++ b/abb_irb120_support/package.xml
@@ -30,7 +30,7 @@
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong (SwRI)</maintainer>
   <license>Apache2</license>
 
-  <url type="website">http://ros.org/wiki/abb_irb120_support</url>
+  <url type="website">http://wiki.ros.org/abb_irb120_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb_experimental/issues</url>
   <url type="repository">https://github.com/ros-industrial/abb_experimental</url>
 

--- a/abb_irb4400_support/CMakeLists.txt
+++ b/abb_irb4400_support/CMakeLists.txt
@@ -9,14 +9,12 @@ catkin_package()
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
   roslaunch_add_file_check(tests/roslaunch_test.xml
-  	DEPENDENCIES
-  	# not nice, but industrial_robot_client doesn't prefix its targets
-  	joint_trajectory_action
-  	abb_driver_robot_state
-  	abb_driver_motion_download_interface)
+    DEPENDENCIES
+      # not nice, but industrial_robot_client doesn't prefix its targets
+      joint_trajectory_action
+      abb_driver_robot_state
+      abb_driver_motion_download_interface)
 endif()
 
-foreach(dir config launch meshes urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/abb_irb4400_support/package.xml
+++ b/abb_irb4400_support/package.xml
@@ -1,33 +1,34 @@
+<?xml version="1.0"?>
 <package>
   <name>abb_irb4400_support</name>
   <version>0.1.0</version>
   <description>
     <p>
-      ROS Industrial support for the ABB IRB4400 (and variants).
+      ROS-Industrial support for the ABB IRB 4400 (and variants).
     </p>
     <p>
-      This package contains configuration data, 3D models and launch files 
-      for ABB IRB4400 manipulators. This currently includes the L30.
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 4400 manipulators. This currently includes the L30.
     </p>
     <p>
-      Joint limits and max joint velocities are based on the information in the 
+      Joint limits and max joint velocities are based on the information in the
       <a href="http://www05.abb.com/global/scot/scot352.nsf/veritydisplay/c90b98aaa057bd6ec12576cb00528ef6/$file/Product%20specification%204400%20M99%20BWOS3.2.pdf">
-      ABB IRB 4400 product specification document</a> (Article No: 3HAC 8770-1).  
-      All urdfs / xacros are based on the default motion and joint velocity 
-      limits, unless noted otherwise (ie: no support for high speed joints, 
+      ABB IRB 4400 product specification document</a> (Article No: 3HAC 8770-1).
+      All urdfs / xacros are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
       extended / limited motion ranges or other options).
     </p>
     <p>
-      Before using any of the configuration files and / or meshes included 
-      in this package, be sure to check they are correct for the particular 
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.
     </p>
   </description>
-  <author email="ds____on@swri.org">Dan Solomon (Southwest Research Institute)</author>
-  <maintainer email="sedewards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <author>Dan Solomon</author>
+  <maintainer email="sedewards@swri.org">Shaun Edwards (SwRI)</maintainer>
   <license>Apache2</license>
 
-  <url type="website">http://ros.org/wiki/abb_irb4400_support</url>
+  <url type="website">http://wiki.ros.org/abb_irb4400_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb_experimental/issues</url>
   <url type="repository">https://github.com/ros-industrial/abb_experimental</url>
 
@@ -36,8 +37,13 @@
   <build_depend version_gte="1.9.55">roslaunch</build_depend>
 
   <run_depend>abb_driver</run_depend>
+  <run_depend>abb_resources</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>rviz</run_depend>
+  <run_depend>xacro</run_depend>
 
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
- added `roslaunch` testing dependencies
- changed `install` rule to for-loop-less variant
- updated run depends and export sections
- made sure there is always at least one core ros-i maintainer
