### PR TITLE
[CI] Fix wrong distro.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: trusty
 language: generic
 compiler:
   - gcc


### PR DESCRIPTION
Travis CI does not support Xenial <s>as of today</s>at the time https://github.com/travis-ci/travis-ci/issues/5821#issuecomment-243617289

Although I'm not sure if this fixes build issues like https://github.com/ros-industrial/industrial_ci/issues/167, with this change Travis passed on my forked repo.

@Jmeyer1292 @ipa-mdl