### PR TITLE
irb4600: mention specific variant supported in manifest.

### DIFF
--- a/abb_irb4600_support/package.xml
+++ b/abb_irb4600_support/package.xml
@@ -38,6 +38,7 @@
   <build_depend>roslaunch</build_depend>
 
   <run_depend>abb_driver</run_depend>
+  <run_depend>abb_resources</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>rviz</run_depend>

--- a/abb_irb4600_support/package.xml
+++ b/abb_irb4600_support/package.xml
@@ -8,7 +8,8 @@
     </p>
     <p>
       This package contains configuration data, 3D models and launch files
-      for ABB IRB 4600 manipulators.
+      for ABB IRB 4600 manipulators. This currently includes the 60/2.05 variant
+      only.
     </p>
     <p>
       Joint limits and max joint velocities are based on the information in the


### PR DESCRIPTION
as per subject.

The package manifest of `abb_irb4600_support` does not make explicit which specific variant(s) it supports.

Updated it to now mention the `60/2.05` variant.
