### PR TITLE
irb1600: add missing mfg prefix on xacro macro.

### DIFF
--- a/abb_irb1600_support/urdf/irb1600_6_12.xacro
+++ b/abb_irb1600_support/urdf/irb1600_6_12.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="irb1600_6_12" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="abb_irb1600_6_12" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find abb_irb1600_support)/urdf/irb1600_6_12_macro.xacro"/>
-  <xacro:irb1600_6_12 prefix=""/>
+  <xacro:abb_irb1600_6_12 prefix=""/>
 </robot>

--- a/abb_irb1600_support/urdf/irb1600_6_12_macro.xacro
+++ b/abb_irb1600_support/urdf/irb1600_6_12_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="irb1600_6_12">
-<xacro:macro name="irb1600_6_12" params="prefix">
+<xacro:macro name="abb_irb1600_6_12" params="prefix">
   <!-- link list -->
   <link name="${prefix}base_link">
     <visual>


### PR DESCRIPTION
As per subject.

Seems to have been missed in the review of #50.
