### PR TITLE
readme: fix links to ROS wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ wstool update
 catkin build
 ```
 
-[ROS-Industrial]: http://www.ros.org/wiki/Industrial
-[ROS wiki]: http://ros.org/wiki/abb_experimental
+[ROS-Industrial]: http://wiki.ros.org/Industrial
+[ROS wiki]: http://wiki.ros.org/abb_experimental
 [wstool]: http://wiki.ros.org/wstool
 [catkin tools]: https://catkin-tools.readthedocs.io/en/latest/


### PR DESCRIPTION
Apparently the old redirects are no longer in place, resulting in `404`s when trying to navigate the links.
