### PR TITLE
Gazebo package for the abb_irb1200

### DIFF
--- a/abb_irb1200_gazebo/CMakeLists.txt
+++ b/abb_irb1200_gazebo/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(abb_irb1200_gazebo)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+foreach(dir config launch urdf)
+ install(DIRECTORY ${dir}/
+         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
+endforeach()
+

--- a/abb_irb1200_gazebo/config/irb1200_5_90_arm_controller.yaml
+++ b/abb_irb1200_gazebo/config/irb1200_5_90_arm_controller.yaml
@@ -1,0 +1,21 @@
+arm_controller:
+  type: position_controllers/JointTrajectoryController
+  joints:
+     - joint_1
+     - joint_2
+     - joint_3
+     - joint_4
+     - joint_5
+     - joint_6
+  constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      joint_1: {trajectory: 0.1, goal: 0.1}
+      joint_2: {trajectory: 0.1, goal: 0.1}
+      joint_3: {trajectory: 0.1, goal: 0.1}
+      joint_4: {trajectory: 0.1, goal: 0.1}
+      joint_5: {trajectory: 0.1, goal: 0.1}
+      joint_6: {trajectory: 0.1, goal: 0.1}
+  stop_trajectory_duration: 0.5
+  state_publish_rate:  25
+  action_monitor_rate: 10

--- a/abb_irb1200_gazebo/config/joint_state_controller.yaml
+++ b/abb_irb1200_gazebo/config/joint_state_controller.yaml
@@ -1,0 +1,3 @@
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 50

--- a/abb_irb1200_gazebo/launch/irb1200_5_90_control.launch
+++ b/abb_irb1200_gazebo/launch/irb1200_5_90_control.launch
@@ -1,0 +1,11 @@
+<launch>
+
+  <!-- load the joint state controller -->
+  <rosparam file="$(find abb_irb1200_gazebo)/config/joint_state_controller.yaml" command="load" />
+  <node name="joint_state_controller_spawner" pkg="controller_manager" type="controller_manager" args="spawn joint_state_controller" />
+
+  <!-- load the arm controller -->
+  <rosparam file="$(find abb_irb1200_gazebo)/config/irb1200_5_90_arm_controller.yaml" command="load" />
+  <node name="abb_irb1200_controller_spawner" pkg="controller_manager" type="controller_manager" args="spawn arm_controller" />
+
+</launch>

--- a/abb_irb1200_gazebo/launch/irb1200_5_90_gazebo.launch
+++ b/abb_irb1200_gazebo/launch/irb1200_5_90_gazebo.launch
@@ -1,0 +1,28 @@
+<launch>
+  <arg name="paused" default="false"/>
+
+  <!-- remap topics to conform to ROS-I specifications -->
+  <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+  <remap from="/arm_controller/state" to="/feedback_states" />
+  <remap from="/arm_controller/command" to="/joint_path_command"/>
+
+  <!-- start simulated world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="worlds/empty.world"/>
+    <arg name="gui" value="true"/>
+    <arg name="paused" value="$(arg paused)"/>
+  </include>
+
+  <!-- load urdf -->
+  <include file="$(find abb_irb1200_gazebo)/launch/load_irb1200_5_90.launch" />
+
+  <!-- spawn robot in gazebo -->
+  <node name="abb_irb1200_spawn" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model abb_irb1200_5_90" />
+
+  <!-- publish joint states in TF -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen" />
+
+  <!-- init and start Gazebo ros_control interface -->
+  <include file="$(find abb_irb1200_gazebo)/launch/irb1200_5_90_control.launch"/>
+
+</launch>

--- a/abb_irb1200_gazebo/launch/load_irb1200_5_90.launch
+++ b/abb_irb1200_gazebo/launch/load_irb1200_5_90.launch
@@ -1,0 +1,3 @@
+<launch>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find abb_irb1200_gazebo)/urdf/irb1200_5_90.xacro'" />
+</launch>

--- a/abb_irb1200_gazebo/package.xml
+++ b/abb_irb1200_gazebo/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>abb_irb1200_gazebo</name>
+  <version>1.2.0</version>
+  <description>
+    <p>
+      Gazebo support for the ABB IRB 1200
+    </p>
+    <p>
+      This package contains configuration and launch files
+      to simulate the ABB IRB 1200 with Gazebo. For now
+      only the 5/0.9 version is supported.
+    </p>
+  </description>
+
+  <author email="stephan@ironox.com">Stephan Wirth</author>
+  <maintainer email="stephan@ironox.com">Stephan Wirth</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>abb_irb1200_support</exec_depend>
+  <exec_depend>gazebo</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo_ros_control</exec_depend>
+  <exec_depend>gazebo_ros_pkgs</exec_depend>
+  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>position_controllers</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros_controllers</exec_depend>
+
+</package>

--- a/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<robot name="abb_irb1200_5_90" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find abb_irb1200_gazebo)/urdf/irb1200_5_90_macro.xacro" />
+  <xacro:include filename="$(find abb_irb1200_support)/urdf/irb1200_5_90_macro.xacro" />
+
+  <!-- get base ABB IRB1200 model -->
+  <xacro:abb_irb1200_5_90 prefix="" />
+
+  <!-- get gazebo add-ons -->
+  <xacro:abb_irb1200_5_90_gazebo_spec prefix="" />
+
+  <!-- connect robot with world -->
+  <link name="world" />
+  <joint name="world_to_base_link_joint" type="fixed">
+    <parent link="world" />
+    <child link="base_link" />
+  </joint>
+
+  <!-- ros_control plugin -->
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>
+
+</robot>

--- a/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="abb_irb1200_5_90_gazebo_spec" params="prefix">
+
+    <!-- transmission list -->
+    <transmission name="${prefix}tran1">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_1">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor1">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran2">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_2">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor2">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran3">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_3">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor3">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran4">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_4">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor4">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran5">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_5">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor5">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran6">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_6">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor6">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <!-- end of transmission list -->
+
+    <!-- Gazebo-specific link properties -->
+    <gazebo reference="${prefix}base_link">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_1">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_2">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_3">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_4">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_5">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_6">
+      <material>Gazebo/Black</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+
+  </xacro:macro>
+</robot>

--- a/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
@@ -5,6 +5,11 @@
   <xacro:macro name="abb_irb1200_5_90" params="prefix">
     <!-- link list -->
     <link name="${prefix}base_link">
+      <inertial>
+        <mass value="6.215"/>
+        <origin xyz="-0.04204 8.01E-05 0.07964" rpy="0 0 0"/>
+        <inertia ixx="0.0247272" ixy="-8.0784E-05" ixz="0.00130902" iyy="0.0491285" iyz="-8.0419E-06" izz="0.0472376"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/base_link.stl"/>
@@ -18,6 +23,11 @@
       </visual>
     </link>
     <link name="${prefix}link_1">
+      <inertial>
+        <mass value="3.067" />
+        <origin xyz="9.77E-05 -0.00012 0.23841" rpy="0 0 0"/>
+        <inertia ixx="0.0142175" ixy="-1.28579E-05" ixz="-2.31364E-05" iyy="0.0144041" iyz="1.93404E-05" izz="0.0104533"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_1.stl"/>
@@ -31,6 +41,11 @@
       </visual>
     </link>
     <link name="${prefix}link_2">
+      <inertial>
+        <mass value="3.909"/>
+        <origin xyz="0.00078 -0.00212 0.10124" rpy="0 0 0"/>
+        <inertia ixx="0.0603111" ixy="9.83431E-06" ixz="5.72407E-05" iyy="0.041569" iyz="-0.00050497" izz="0.0259548"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_2.stl"/>
@@ -44,6 +59,11 @@
       </visual>
     </link>
     <link name="${prefix}link_3">
+      <inertial>
+        <mass value="2.944"/>
+        <origin xyz="0.02281 0.00106 0.05791" rpy="0 0 0"/>
+        <inertia ixx="0.00835606" ixy="-8.01545E-05" ixz="0.00142884" iyy="0.016713" iyz="-0.000182227" izz="0.0126984"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_3.stl"/>
@@ -57,6 +77,11 @@
       </visual>
     </link>
     <link name="${prefix}link_4">
+      <inertial>
+        <mass value="1.328"/>
+        <origin xyz="0.2247 0.00015 0.00041" rpy="0 0 0"/>
+        <inertia ixx="0.00284661" ixy="-2.12765E-05" ixz="-1.6435E-05" iyy="0.00401346" iyz="1.31336E-05" izz="0.0052535"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_4.stl"/>
@@ -70,6 +95,11 @@
       </visual>
     </link>
     <link name="${prefix}link_5">
+      <inertial>
+        <mass value="0.546"/>
+        <origin xyz="-0.00109 3.68E-05 6.22E-05" rpy="0 0 0"/>
+        <inertia ixx="0.000404891" ixy="1.61943E-06" ixz="8.46805E-07" iyy="0.000892825" iyz="-1.51792E-08" izz="0.000815468"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_5.stl"/>
@@ -83,6 +113,11 @@
       </visual>
     </link>
     <link name="${prefix}link_6">
+      <inertial>
+        <mass value="0.137"/>
+        <origin xyz="-0.00706 -0.00017 -1.32E-06" rpy="0 0 0"/>
+        <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_6.stl"/>

--- a/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find abb_resources)/urdf/common_materials.xacro"/>
 
+  <!-- inertial values are copied from irb120_3_58 and are therefore not accurate,
+       use at your own risk! -->
   <xacro:macro name="abb_irb1200_5_90" params="prefix">
     <!-- link list -->
     <link name="${prefix}base_link">


### PR DESCRIPTION
Adds a gazebo package for the abb_irb1200. For now this package only contains files for the 5_90 variant.
I had to add inertial values to the robot's URDF in the abb_irb1200_support package to make gazebo happy. Those values are not accurate though, they are stolen from abb_irb120_gazebo (see also https://github.com/ros-industrial/abb_experimental/issues/97).

![image](https://user-images.githubusercontent.com/1481786/39348815-eee3adc6-49f8-11e8-89e9-6f9303d5f2e9.png)

You can test this running:
```
$ roslaunch abb_irb1200_gazebo irb1200_5_90_gazebo.launch
$ rosrun rqt_joint_trajectory_controller rqt_joint_trajectory_controller arm_controller/command:=joint_path_command arm_controller/state:=feedback_states
```