### PR TITLE
Add gazebo support for IRB1200 5/90 variant

### DIFF
--- a/abb_irb1200_gazebo/CMakeLists.txt
+++ b/abb_irb1200_gazebo/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(abb_irb1200_gazebo)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+foreach(dir config launch urdf)
+ install(DIRECTORY ${dir}/
+         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
+endforeach()
+

--- a/abb_irb1200_gazebo/config/irb1200_5_90_arm_controller.yaml
+++ b/abb_irb1200_gazebo/config/irb1200_5_90_arm_controller.yaml
@@ -1,0 +1,28 @@
+arm_controller:
+  type: effort_controllers/JointTrajectoryController
+  joints:
+     - joint_1
+     - joint_2
+     - joint_3
+     - joint_4
+     - joint_5
+     - joint_6
+  gains:
+    joint_1: {p: 1000.0, i: 500.0, d: 20.0}
+    joint_2: {p: 1000.0, i: 500.0, d: 20.0}
+    joint_3: {p: 1000.0, i: 500.0, d: 20.0}
+    joint_4: {p: 200.0, i: 100.0, d: 0.0}
+    joint_5: {p: 100.0, i: 1.0, d: 0.0}
+    joint_6: {p: 100.0, i: 20.0, d: 0.0}
+  constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      joint_1: {trajectory: 0.1, goal: 0.1}
+      joint_2: {trajectory: 0.1, goal: 0.1}
+      joint_3: {trajectory: 0.1, goal: 0.1}
+      joint_4: {trajectory: 0.1, goal: 0.1}
+      joint_5: {trajectory: 0.1, goal: 0.1}
+      joint_6: {trajectory: 0.1, goal: 0.1}
+  stop_trajectory_duration: 0.5
+  state_publish_rate:  25
+  action_monitor_rate: 10

--- a/abb_irb1200_gazebo/config/joint_state_controller.yaml
+++ b/abb_irb1200_gazebo/config/joint_state_controller.yaml
@@ -1,0 +1,3 @@
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 50

--- a/abb_irb1200_gazebo/launch/irb1200_5_90_control.launch
+++ b/abb_irb1200_gazebo/launch/irb1200_5_90_control.launch
@@ -1,0 +1,11 @@
+<launch>
+
+  <!-- load the joint state controller -->
+  <rosparam file="$(find abb_irb1200_gazebo)/config/joint_state_controller.yaml" command="load" />
+  <node name="joint_state_controller_spawner" pkg="controller_manager" type="controller_manager" args="spawn joint_state_controller" />
+
+  <!-- load the arm controller -->
+  <rosparam file="$(find abb_irb1200_gazebo)/config/irb1200_5_90_arm_controller.yaml" command="load" />
+  <node name="abb_irb1200_controller_spawner" pkg="controller_manager" type="controller_manager" args="spawn arm_controller" />
+
+</launch>

--- a/abb_irb1200_gazebo/launch/irb1200_5_90_gazebo.launch
+++ b/abb_irb1200_gazebo/launch/irb1200_5_90_gazebo.launch
@@ -1,0 +1,28 @@
+<launch>
+  <arg name="paused" default="false"/>
+
+  <!-- remap topics to conform to ROS-I specifications -->
+  <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+  <remap from="/arm_controller/state" to="/feedback_states" />
+  <remap from="/arm_controller/command" to="/joint_path_command"/>
+
+  <!-- start simulated world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="worlds/empty.world"/>
+    <arg name="gui" value="true"/>
+    <arg name="paused" value="$(arg paused)"/>
+  </include>
+
+  <!-- load urdf -->
+  <include file="$(find abb_irb1200_gazebo)/launch/load_irb1200_5_90.launch" />
+
+  <!-- spawn robot in gazebo -->
+  <node name="abb_irb1200_spawn" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model abb_irb1200_5_90" />
+
+  <!-- publish joint states in TF -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen" />
+
+  <!-- init and start Gazebo ros_control interface -->
+  <include file="$(find abb_irb1200_gazebo)/launch/irb1200_5_90_control.launch"/>
+
+</launch>

--- a/abb_irb1200_gazebo/launch/load_irb1200_5_90.launch
+++ b/abb_irb1200_gazebo/launch/load_irb1200_5_90.launch
@@ -1,0 +1,3 @@
+<launch>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find abb_irb1200_gazebo)/urdf/irb1200_5_90.xacro'" />
+</launch>

--- a/abb_irb1200_gazebo/package.xml
+++ b/abb_irb1200_gazebo/package.xml
@@ -44,7 +44,6 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>ros_controllers</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/abb_irb1200_gazebo/package.xml
+++ b/abb_irb1200_gazebo/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>abb_irb1200_gazebo</name>
+  <version>0.0.1</version>
+  <description>
+    <p>
+      Gazebo support for the ABB IRB 1200
+    </p>
+    <p>
+      This package contains configuration and launch files
+      to simulate the ABB IRB 1200 with Gazebo.
+    </p>
+  </description>
+
+  <author email="stephan@ironox.com">Stephan Wirth</author>
+  <maintainer email="lucas@ironox.com">Lucas Chiesa</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>abb_irb1200_support</exec_depend>
+  <exec_depend>gazebo_ros_control</exec_depend>
+  <exec_depend>gazebo_ros_pkgs</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo</exec_depend>
+  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>position_controllers</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros_controllers</exec_depend>
+
+  <export>
+  </export>
+</package>

--- a/abb_irb1200_gazebo/package.xml
+++ b/abb_irb1200_gazebo/package.xml
@@ -4,36 +4,49 @@
   <version>0.0.1</version>
   <description>
     <p>
-      Gazebo support for the ABB IRB 1200
+      ROS-Industrial Gazebo support package for the ABB IRB 1200 (and variants).
     </p>
     <p>
-      This package currently only contains configuration and launch files to
-      simulate the 5/0.9 variant of the ABB IRB 1200 robot.
+      This package contains the configuration data and launch files required
+      to simulate the ABB IRB 1200 manipulator in Gazebo. This currently only
+      includes the 5/0.9 variant.
     </p>
     <p>
-      Ros control <em>effort_controllers</em> are used to move the robot joints.
-      The controller params (PID, constrains) are guesstimates, and were
+      `ros_control` `effort_controllers` are used to move the robot joints.
+      The controller parameters (PID, constrains) are guesstimates, and were
       obtained testing different values until the joint movement was good enough
       for the intended application. You may need to change them for your simulation.
     </p>
+    <p>
+      Before using any of the configuration files included in this package, be
+      sure to check they are correct for the particular robot model and
+      configuration you intend to use them with.
+    </p>
   </description>
-
   <author email="stephan@ironox.com">Stephan Wirth</author>
   <maintainer email="lucas@ironox.com">Lucas Chiesa</maintainer>
-
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>Apache 2.0</license>
+
+  <url type="website">http://wiki.ros.org/abb</url>
+  <url type="bugtracker">https://github.com/ros-industrial/abb_experimental/issues</url>
+  <url type="repository">https://github.com/ros-industrial/abb_experimental</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>abb_irb1200_support</exec_depend>
+  <exec_depend>gazebo</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo_ros_control</exec_depend>
   <exec_depend>gazebo_ros_pkgs</exec_depend>
-  <exec_depend>gazebo_ros</exec_depend>
-  <exec_depend>gazebo</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros_controllers</exec_depend>
 
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/abb_irb1200_gazebo/package.xml
+++ b/abb_irb1200_gazebo/package.xml
@@ -8,7 +8,7 @@
     </p>
     <p>
       This package contains configuration and launch files
-      to simulate the ABB IRB 1200 with Gazebo.
+      to simulate the ABB IRB 1200-5/90 with Gazebo.
     </p>
   </description>
 
@@ -30,6 +30,4 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros_controllers</exec_depend>
 
-  <export>
-  </export>
 </package>

--- a/abb_irb1200_gazebo/package.xml
+++ b/abb_irb1200_gazebo/package.xml
@@ -7,8 +7,14 @@
       Gazebo support for the ABB IRB 1200
     </p>
     <p>
-      This package contains configuration and launch files
-      to simulate the ABB IRB 1200-5/90 with Gazebo.
+      This package currently only contains configuration and launch files to
+      simulate the 5/0.9 variant of the ABB IRB 1200 robot.
+    </p>
+    <p>
+      Ros control <em>effort_controllers</em> are used to move the robot joints.
+      The controller params (PID, constrains) are guesstimates, and were
+      obtained testing different values until the joint movement was good enough
+      for the intended application. You may need to change them for your simulation.
     </p>
   </description>
 

--- a/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
@@ -2,13 +2,8 @@
 
 <robot name="abb_irb1200_5_90" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find abb_irb1200_gazebo)/urdf/irb1200_5_90_macro.xacro" />
-  <xacro:include filename="$(find abb_irb1200_support)/urdf/irb1200_5_90_macro.xacro" />
 
-  <!-- get base ABB IRB1200 model -->
-  <xacro:abb_irb1200_5_90 prefix="" />
-
-  <!-- get gazebo add-ons -->
-  <xacro:abb_irb1200_5_90_gazebo_spec prefix="" />
+  <xacro:abb_irb1200_5_90_gazebo prefix="" />
 
   <!-- connect robot with world -->
   <link name="world" />

--- a/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+
+<robot name="abb_irb1200_5_90" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find abb_irb1200_gazebo)/urdf/irb1200_5_90_macro.xacro" />
+  <xacro:include filename="$(find abb_irb1200_support)/urdf/irb1200_5_90_macro.xacro" />
+
+  <!-- get base ABB IRB1200 model -->
+  <xacro:abb_irb1200_5_90 prefix="" />
+
+  <!-- get gazebo add-ons -->
+  <xacro:abb_irb1200_5_90_gazebo_spec prefix="" />
+
+  <!-- connect robot with world -->
+  <link name="world" />
+  <joint name="world_to_base_link_joint" type="fixed">
+    <parent link="world" />
+    <child link="base_link" />
+  </joint>
+
+  <!-- ros_control plugin -->
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotNamespace>/</robotNamespace>
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>
+
+</robot>

--- a/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="abb_irb1200_5_90_gazebo_spec" params="prefix">
+  <xacro:include filename="$(find abb_irb1200_support)/urdf/irb1200_5_90_macro.xacro" />
+  <xacro:macro name="abb_irb1200_5_90_gazebo" params="prefix">
+
+    <!-- get base ABB IRB1200 model -->
+    <xacro:abb_irb1200_5_90 prefix="${prefix}" />
 
     <!-- transmission list -->
     <transmission name="${prefix}tran1">

--- a/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="abb_irb1200_5_90_gazebo_spec" params="prefix">
+
+    <!-- transmission list -->
+    <transmission name="${prefix}tran1">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_1">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor1">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran2">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_2">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor2">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran3">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_3">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor3">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran4">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_4">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor4">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran5">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_5">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor5">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran6">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_6">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor6">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <!-- end of transmission list -->
+
+    <!-- Gazebo-specific link properties -->
+    <gazebo reference="${prefix}base_link">
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_1">
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_2">
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_3">
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_4">
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_5">
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_6">
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+
+  </xacro:macro>
+</robot>

--- a/abb_irb1200_support/package.xml
+++ b/abb_irb1200_support/package.xml
@@ -19,6 +19,13 @@
       extended / limited motion ranges or other options).
     </p>
     <p>
+      Inertial values for the 5/0.9 variant were calculated from the meshes
+      using <em>Meshlab</em>, assuming constant density.
+      As the datasheet only provides the mass of the entire robot,
+      the mass of each link was estimated based on its volume, assuming
+      constant density on the entire robot.
+    </p>
+    <p>
       Before using any of the configuration files and / or meshes included
       in this package, be sure to check they are correct for the particular
       robot model and configuration you intend to use them with.

--- a/abb_irb1200_support/package.xml
+++ b/abb_irb1200_support/package.xml
@@ -19,11 +19,17 @@
       extended / limited motion ranges or other options).
     </p>
     <p>
-      Inertial values for the 5/0.9 variant were calculated from the meshes
-      using <em>Meshlab</em>, assuming constant density.
+      Note 1: inertial and dynamics values for the 5/0.9 variant were calculated
+      from the meshes using <em>Meshlab</em>, assuming constant density.
       As the datasheet only provides the mass of the entire robot,
       the mass of each link was estimated based on its volume, assuming
-      constant density on the entire robot.
+      constant density for the entire robot.
+    </p>
+    <p>
+      Note 2: maximum joint effort values for the 5/0.9 variant do not
+      correspond to real world limits of the robot. The current values were
+      chosen to accomodate Gazebo simulations of this specific variant but
+      are fictional values.
     </p>
     <p>
       Before using any of the configuration files and / or meshes included

--- a/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
@@ -5,6 +5,11 @@
   <xacro:macro name="abb_irb1200_5_90" params="prefix">
     <!-- link list -->
     <link name="${prefix}base_link">
+      <inertial>
+        <mass value="13.7742"/>
+        <origin xyz="-0.028986 0.000596 0.11273"/>
+        <inertia ixx="0.101998" ixy="0.000495482" ixz="0.000311158" iyy="0.13969" iyz="-0.000245375" izz="0.130433"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/base_link.stl"/>
@@ -18,6 +23,11 @@
       </visual>
     </link>
     <link name="${prefix}link_1">
+      <inertial>
+        <mass value="11.8419"/>
+        <origin xyz="0.000877 -0.000631 -0.062883"/>
+        <inertia ixx="0.11194" ixy="-4.54988e-05" ixz="0.000280961" iyy="0.0915159" iyz="-0.000109905" izz="0.0876456"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_1.stl"/>
@@ -31,6 +41,11 @@
       </visual>
     </link>
     <link name="${prefix}link_2">
+      <inertial>
+        <mass value="17.5394"/>
+        <origin xyz="-0.000928 -0.000497 0.250051"/>
+        <inertia ixx="0.493558" ixy="1.32136e-05" ixz="0.000209024" iyy="0.462939" iyz="-0.00179901" izz="0.0894214"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_2.stl"/>
@@ -44,6 +59,11 @@
       </visual>
     </link>
     <link name="${prefix}link_3">
+      <inertial>
+        <mass value="7.46365"/>
+        <origin xyz="0.099588 0.001143 0.032333"/>
+        <inertia ixx="0.0252424" ixy="0.000142737" ixz="-0.00565542" iyy="0.0906438" iyz="0.000142213" izz="0.0825079"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_3.stl"/>
@@ -57,6 +77,11 @@
       </visual>
     </link>
     <link name="${prefix}link_4">
+      <inertial>
+        <mass value="2.74436"/>
+        <origin xyz="0.381678 0.001261 0.005168"/>
+        <inertia ixx="0.00573099" ixy="-0.000131119" ixz="0.000380232" iyy="0.0118352" iyz="-2.26565e-05" izz="0.0114428"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_4.stl"/>
@@ -70,6 +95,11 @@
       </visual>
     </link>
     <link name="${prefix}link_5">
+      <inertial>
+        <mass value="0.62953"/>
+        <origin xyz="0.011197 -0.001056 0.000109"/>
+        <inertia ixx="0.000502815" ixy="-1.03173e-05" ixz="-8.74347e-08" iyy="0.00108856" iyz="2.07657e-07" izz="0.000918873"/>
+      </inertial>
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_5.stl"/>
@@ -83,6 +113,17 @@
       </visual>
     </link>
     <link name="${prefix}link_6">
+      <inertial>
+        <mass value="0.137"/>
+        <origin xyz="-0.00706 -0.00017 -1.32E-06" rpy="0 0 0"/>
+        <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+      </inertial>
+      <!-- Meshlab calculated values (below) make gazebo crash when rotating this joint. -->
+      <!-- <inertial>
+        <mass value="0.00686711"/>
+        <origin xyz="-0.00250976 -1.89e-06 0.00010218"/>
+        <inertia ixx="1.3517e-06" ixy="-1.21316e-11" ixz="9.18065e-12" iyy="6.89813e-07" iyz="-1.21534e-10" izz="6.90097e-07"/>
+      </inertial> -->
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_6.stl"/>
@@ -104,42 +145,48 @@
       <axis xyz="0 0 1"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}link_1"/>
-      <limit effort="0" lower="-2.967" upper="2.967" velocity="5.027"/>
+      <limit effort="1000" lower="-2.967" upper="2.967" velocity="5.027"/>
+      <dynamics damping="50.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_2">
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <axis xyz="0 1 0"/>
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
-      <limit effort="0" lower="-1.745" upper="2.269" velocity="4.189"/>
+      <limit effort="1000" lower="-1.745" upper="2.269" velocity="4.189"/>
+      <dynamics damping="50.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_3">
       <origin xyz="0 0 0.448" rpy="0 0 0"/>
       <axis xyz="0 1 0"/>
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
-      <limit effort="0" lower="-3.491" upper="1.222" velocity="5.236"/>
+      <limit effort="1000" lower="-3.491" upper="1.222" velocity="5.236"/>
+      <dynamics damping="10.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_4">
       <origin xyz="0 0 0.042" rpy="0 0 0"/>
       <axis xyz="1 0 0"/>
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
-      <limit effort="0" lower="-4.712" upper="4.712" velocity="6.981"/>
+      <limit effort="1000" lower="-4.712" upper="4.712" velocity="6.981"/>
+      <dynamics damping="5.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_5">
       <origin xyz="0.451 0 0" rpy="0 0 0"/>
       <axis xyz="0 1 0"/>
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
-      <limit effort="0" lower="-2.269" upper="2.269" velocity="7.069"/>
+      <limit effort="1000" lower="-2.269" upper="2.269" velocity="7.069"/>
+      <dynamics damping="2.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_6">
       <origin xyz="0.082 0 0" rpy="0 0 0"/>
       <axis xyz="1 0 0"/>
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
-      <limit effort="0" lower="-6.283" upper="6.283" velocity="10.472"/>
+      <limit effort="1000" lower="-6.283" upper="6.283" velocity="10.472"/>
+      <dynamics damping="1.0" friction="1.0"/>
     </joint>
     <joint type="fixed" name="${prefix}joint_6-tool0">
       <parent link="${prefix}link_6"/>

--- a/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
@@ -5,6 +5,7 @@
   <xacro:macro name="abb_irb1200_5_90" params="prefix">
     <!-- link list -->
     <link name="${prefix}base_link">
+      <!-- See note 1 in package.xml about the inertial and mass values -->
       <inertial>
         <mass value="13.7742"/>
         <origin xyz="-0.028986 0.000596 0.11273"/>
@@ -23,6 +24,7 @@
       </visual>
     </link>
     <link name="${prefix}link_1">
+      <!-- See note 1 in package.xml about the inertial and mass values -->
       <inertial>
         <mass value="11.8419"/>
         <origin xyz="0.000877 -0.000631 -0.062883"/>
@@ -41,6 +43,7 @@
       </visual>
     </link>
     <link name="${prefix}link_2">
+      <!-- See note 1 in package.xml about the inertial and mass values -->
       <inertial>
         <mass value="17.5394"/>
         <origin xyz="-0.000928 -0.000497 0.250051"/>
@@ -59,6 +62,7 @@
       </visual>
     </link>
     <link name="${prefix}link_3">
+      <!-- See note 1 in package.xml about the inertial and mass values -->
       <inertial>
         <mass value="7.46365"/>
         <origin xyz="0.099588 0.001143 0.032333"/>
@@ -77,6 +81,7 @@
       </visual>
     </link>
     <link name="${prefix}link_4">
+      <!-- See note 1 in package.xml about the inertial and mass values -->
       <inertial>
         <mass value="2.74436"/>
         <origin xyz="0.381678 0.001261 0.005168"/>
@@ -95,6 +100,7 @@
       </visual>
     </link>
     <link name="${prefix}link_5">
+      <!-- See note 1 in package.xml about the inertial and mass values -->
       <inertial>
         <mass value="0.62953"/>
         <origin xyz="0.011197 -0.001056 0.000109"/>
@@ -113,6 +119,7 @@
       </visual>
     </link>
     <link name="${prefix}link_6">
+      <!-- See note 1 in package.xml about the inertial and mass values -->
       <inertial>
         <mass value="0.137"/>
         <origin xyz="-0.00706 -0.00017 -1.32E-06" rpy="0 0 0"/>
@@ -145,6 +152,7 @@
       <axis xyz="0 0 1"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}link_1"/>
+      <!-- See note 2 in package.xml about effort limits and dynamics values -->
       <limit effort="1000" lower="-2.967" upper="2.967" velocity="5.027"/>
       <dynamics damping="50.0" friction="1.0"/>
     </joint>
@@ -153,6 +161,7 @@
       <axis xyz="0 1 0"/>
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
+      <!-- See note 2 in package.xml about effort limits and dynamics values -->
       <limit effort="1000" lower="-1.745" upper="2.269" velocity="4.189"/>
       <dynamics damping="50.0" friction="1.0"/>
     </joint>
@@ -161,6 +170,7 @@
       <axis xyz="0 1 0"/>
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
+      <!-- See note 2 in package.xml about effort limits and dynamics values -->
       <limit effort="1000" lower="-3.491" upper="1.222" velocity="5.236"/>
       <dynamics damping="10.0" friction="1.0"/>
     </joint>
@@ -169,6 +179,7 @@
       <axis xyz="1 0 0"/>
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
+      <!-- See note 2 in package.xml about effort limits and dynamics values -->
       <limit effort="1000" lower="-4.712" upper="4.712" velocity="6.981"/>
       <dynamics damping="5.0" friction="1.0"/>
     </joint>
@@ -177,6 +188,7 @@
       <axis xyz="0 1 0"/>
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
+      <!-- See note 2 in package.xml about effort limits and dynamics values -->
       <limit effort="1000" lower="-2.269" upper="2.269" velocity="7.069"/>
       <dynamics damping="2.0" friction="1.0"/>
     </joint>
@@ -185,6 +197,7 @@
       <axis xyz="1 0 0"/>
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
+      <!-- See note 2 in package.xml about effort limits and dynamics values -->
       <limit effort="1000" lower="-6.283" upper="6.283" velocity="10.472"/>
       <dynamics damping="1.0" friction="1.0"/>
     </joint>


### PR DESCRIPTION
* Adds the irb1200_gazebo package with support for the 5 90 variant using effort controllers.
* Adds inertial values to abb_irb1200_support irb1200_5_90 xacro file

This is built upon the initial work of @stwirth (https://github.com/ros-industrial/abb_experimental/pull/98) and @jonbinney

## Intertials

Meshlab was used to calculate the inertia tensor, the center of mass and the volume of each collision mesh. This is the method explained in this [very well known tutorial](http://gazebosim.org/tutorials?tut=inertia). Meshes were scaled 10 times to get better results.

To calculate each link mass a constant density in the entire robot was assumed and then distributed the mass using the calculated volume of each link.

I used the obtained values for all joints except for `joint_6` where they made the robot "crash". Maybe it's because the values are too small?

The new inertials look like this:
![screenshot from 2019-02-28 19-56-24](https://user-images.githubusercontent.com/764126/53590851-fbf65680-3b92-11e9-9ef4-46267a9e9393.png)

I tested the cylinder approximation for link 6 but those values failed in the same way, and were also very small.

## Dynamics and control

Gazebo plotting tool was use to get and idea of the robot responses to motion commands. The original values made the robot oscillate significantly while moving, as can be seen on this plot:
![screenshot from 2019-02-28 18-58-01](https://user-images.githubusercontent.com/764126/53590931-26481400-3b93-11e9-8705-d87d78874003.png)

The new values make the robot move smoothly and pretty quickly:
![screenshot from 2019-02-28 19-43-44](https://user-images.githubusercontent.com/764126/53590304-c2711b80-3b91-11e9-91bc-dba072267589.png)

I'm pretty sure that we can find even better values if we keep tuning, for example to reduce even more the steady state errors, but I believe that the proposed values are already very adequate.

## Testing

Start the simulation:
```
$ roslaunch abb_irb1200_gazebo  irb1200_5_90_gazebo.launch
```
Test the controllers:
```
$ rosrun rqt_joint_trajectory_controller rqt_joint_trajectory_controller arm_controller/command:=joint_path_command arm_controller/state:=feedback_states
```
