### PR TITLE
irb120: remove roslaunch_check deps.

### DIFF
--- a/abb_irb120_support/CMakeLists.txt
+++ b/abb_irb120_support/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
+
 project(abb_irb120_support)
 
 find_package(catkin REQUIRED)
@@ -7,11 +8,7 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml
-    DEPENDENCIES
-      # not nice, but industrial_robot_client doesn't prefix its targets
-      joint_trajectory_action
-      abb_driver_robot_state)
+  roslaunch_add_file_check(tests/roslaunch_test.xml)
 endif()
 
 install(DIRECTORY config launch meshes urdf


### PR DESCRIPTION
As per subject.

Avoids a slew of CMake warnings printed during building.
