### PR TITLE
Fix length of link5 in IRB4600-20/2.50

### DIFF
--- a/abb_irb4600_support/urdf/irb4600_20_250_macro.xacro
+++ b/abb_irb4600_support/urdf/irb4600_20_250_macro.xacro
@@ -143,7 +143,7 @@
       <limit effort="0" lower="${radians(-400)}" upper="${radians(400)}" velocity="${radians(360)}"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_5">
-      <origin xyz="1.235 0 0" rpy="0 0 0"/>
+      <origin xyz="1.2305 0 0" rpy="0 0 0"/>
       <axis xyz="0 1 0"/>
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>


### PR DESCRIPTION
According to https://library.e.abb.com/public/fcaa8b25ff844fe5a115aa00b5a1578d/3HAC032885%20PS%20IRB%204600-en.pdf  there is a `0` missing

Seems to be a good idea to write opw configs based on original specifications