### PR TITLE
Increase minimum CMake version to allow builds on Focal Fossa (Noetic)

### DIFF
--- a/abb_crb15000_support/CMakeLists.txt
+++ b/abb_crb15000_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_crb15000_support)
 

--- a/abb_experimental/CMakeLists.txt
+++ b/abb_experimental/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_experimental)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/abb_irb1200_5_90_moveit_config/CMakeLists.txt
+++ b/abb_irb1200_5_90_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb1200_5_90_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/abb_irb1200_7_70_moveit_config/CMakeLists.txt
+++ b/abb_irb1200_7_70_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb1200_7_70_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/abb_irb1200_gazebo/CMakeLists.txt
+++ b/abb_irb1200_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb1200_gazebo)
 
 find_package(catkin REQUIRED)

--- a/abb_irb1200_support/CMakeLists.txt
+++ b/abb_irb1200_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb1200_support)
 

--- a/abb_irb120_gazebo/CMakeLists.txt
+++ b/abb_irb120_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb120_gazebo)
 
 find_package(catkin REQUIRED)

--- a/abb_irb120_moveit_config/CMakeLists.txt
+++ b/abb_irb120_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb120_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/abb_irb120_support/CMakeLists.txt
+++ b/abb_irb120_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb120_support)
 

--- a/abb_irb120t_moveit_config/CMakeLists.txt
+++ b/abb_irb120t_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb120t_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/abb_irb1600_6_12_moveit_config/CMakeLists.txt
+++ b/abb_irb1600_6_12_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb1600_6_12_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/abb_irb1600_support/CMakeLists.txt
+++ b/abb_irb1600_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb1600_support)
 

--- a/abb_irb2600_support/CMakeLists.txt
+++ b/abb_irb2600_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb2600_support)
 

--- a/abb_irb4600_support/CMakeLists.txt
+++ b/abb_irb4600_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb4600_support)
 

--- a/abb_irb52_support/CMakeLists.txt
+++ b/abb_irb52_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb52_support)
 

--- a/abb_irb6650s_support/CMakeLists.txt
+++ b/abb_irb6650s_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb6650s_support)
 

--- a/abb_irb6700_support/CMakeLists.txt
+++ b/abb_irb6700_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb6700_support)
 

--- a/abb_irb7600_support/CMakeLists.txt
+++ b/abb_irb7600_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(abb_irb7600_support)
 


### PR DESCRIPTION
Related to https://github.com/ros-industrial/ros_industrial_issues/issues/67