### PR TITLE
Correct `J23_coupled` default for serial robots (rebased #139)

### DIFF
--- a/abb_irb1600_support/launch/robot_interface_download_irb1600_10_145.launch
+++ b/abb_irb1600_support/launch/robot_interface_download_irb1600_10_145.launch
@@ -9,7 +9,7 @@
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb1600_support)/config/joint_names_irb1600_10_145.yaml" />
 

--- a/abb_irb1600_support/launch/robot_interface_download_irb1600_6_12.launch
+++ b/abb_irb1600_support/launch/robot_interface_download_irb1600_6_12.launch
@@ -2,14 +2,14 @@
   Manipulator specific version of abb_driver's 'robot_interface.launch'.
 
   Defaults provided for IRB 1600:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb1600.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb1600_support)/config/joint_names_irb1600_6_12.yaml" />
 

--- a/abb_irb1600_support/launch/robot_interface_download_irb1600_8_145.launch
+++ b/abb_irb1600_support/launch/robot_interface_download_irb1600_8_145.launch
@@ -2,14 +2,14 @@
   Manipulator specific version of abb_driver's 'robot_interface.launch'.
 
   Defaults provided for IRB 1600:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb1600.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb1600_support)/config/joint_names_irb1600_8_145.yaml" />
 

--- a/abb_irb1600_support/launch/robot_state_visualize_irb1600_10_145.launch
+++ b/abb_irb1600_support/launch/robot_state_visualize_irb1600_10_145.launch
@@ -9,7 +9,7 @@
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb1600_support)/config/joint_names_irb1600_10_145.yaml" />
 

--- a/abb_irb1600_support/launch/robot_state_visualize_irb1600_6_12.launch
+++ b/abb_irb1600_support/launch/robot_state_visualize_irb1600_6_12.launch
@@ -1,15 +1,15 @@
 <!--
   Manipulator specific version of the state visualizer.
 
-  Defaults provided for IRB 2400:
-   - J23_coupled = true
+  Defaults provided for IRB 1600:
+   - J23_coupled = false
 
   Usage:
-    robot_state_visualize_irb2400.launch robot_ip:=<value>
+    robot_state_visualize_irb1600.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb1600_support)/config/joint_names_irb1600_6_12.yaml" />
 

--- a/abb_irb1600_support/launch/robot_state_visualize_irb1600_8_145.launch
+++ b/abb_irb1600_support/launch/robot_state_visualize_irb1600_8_145.launch
@@ -1,15 +1,15 @@
 <!--
   Manipulator specific version of the state visualizer.
 
-  Defaults provided for IRB 2400:
-   - J23_coupled = true
+  Defaults provided for IRB 1600:
+   - J23_coupled = false
 
   Usage:
-    robot_state_visualize_irb2400.launch robot_ip:=<value>
+    robot_state_visualize_irb1600.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb1600_support)/config/joint_names_irb1600_8_145.yaml" />
 

--- a/abb_irb52_support/launch/robot_interface_download_irb52_7_120.launch
+++ b/abb_irb52_support/launch/robot_interface_download_irb52_7_120.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of abb driver's 'robot_interface.launch'.
 
   Defaults provided for IRB 52-7/1.20:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb52_7_120.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb52_support)/config/joint_names_irb52_7_120.yaml" />
 

--- a/abb_irb52_support/launch/robot_interface_download_irb52_7_145.launch
+++ b/abb_irb52_support/launch/robot_interface_download_irb52_7_145.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of abb driver's 'robot_interface.launch'.
 
   Defaults provided for IRB 52-7/1.45:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb52_7_145.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb52_support)/config/joint_names_irb52_7_145.yaml" />
 

--- a/abb_irb52_support/launch/robot_state_visualize_irb52_7_120.launch
+++ b/abb_irb52_support/launch/robot_state_visualize_irb52_7_120.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of the state visualizer.
 
   Defaults provided for IRB 52-7/1.20:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_state_visualize_irb52_7_120.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb52_support)/config/joint_names_irb52_7_120.yaml" />
 

--- a/abb_irb52_support/launch/robot_state_visualize_irb52_7_145.launch
+++ b/abb_irb52_support/launch/robot_state_visualize_irb52_7_145.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of the state visualizer.
 
   Defaults provided for IRB 52-7/1.45:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_state_visualize_irb52_7_145.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb52_support)/config/joint_names_irb52_7_145.yaml" />
 

--- a/abb_irb6650s_support/launch/robot_interface_download_irb6650s_125_350.launch
+++ b/abb_irb6650s_support/launch/robot_interface_download_irb6650s_125_350.launch
@@ -2,14 +2,14 @@
   Manipulator specific version of abb driver's 'robot_interface.launch'.
 
   Defaults provided for irb_6650s_125:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb_6650s_125.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6650s_support)/config/joint_names_irb6650s_125_350.yaml" />
 

--- a/abb_irb6650s_support/launch/robot_interface_download_irb6650s_90_390.launch
+++ b/abb_irb6650s_support/launch/robot_interface_download_irb6650s_90_390.launch
@@ -2,14 +2,14 @@
   Manipulator specific version of abb driver's 'robot_interface.launch'.
 
   Defaults provided for irb_6650s_90:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb_6650s_90.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6650s_support)/config/joint_names_irb6650s_90_390.yaml" />
 

--- a/abb_irb6650s_support/launch/robot_state_visualize_irb6650s_125_350.launch
+++ b/abb_irb6650s_support/launch/robot_state_visualize_irb6650s_125_350.launch
@@ -2,14 +2,14 @@
   Manipulator specific version of the state visualizer.
 
   Defaults provided for irb_6650s_125:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_state_visualize_irb_6650s_125.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6650s_support)/config/joint_names_irb6650s_125_350.yaml" />
 

--- a/abb_irb6650s_support/launch/robot_state_visualize_irb6650s_90_390.launch
+++ b/abb_irb6650s_support/launch/robot_state_visualize_irb6650s_90_390.launch
@@ -2,14 +2,14 @@
   Manipulator specific version of the state visualizer.
 
   Defaults provided for irb_6650s_90:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_state_visualize_irb_6650s_90.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6650s_support)/config/joint_names_irb6650s_90_390.yaml" />
 

--- a/abb_irb6700_support/launch/robot_interface_download_irb6700_200_260.launch
+++ b/abb_irb6700_support/launch/robot_interface_download_irb6700_200_260.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of abb driver's 'robot_interface.launch'.
 
   Defaults provided for IRB 6700-200/2.60:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb6700_200_260.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6700_support)/config/joint_names_irb6700_200_260.yaml" />
 

--- a/abb_irb6700_support/launch/robot_interface_download_irb6700_235_265.launch
+++ b/abb_irb6700_support/launch/robot_interface_download_irb6700_235_265.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of abb driver's 'robot_interface.launch'.
 
   Defaults provided for IRB 6700-235/2.65:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb6700_235_265.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6700_support)/config/joint_names_irb6700_235_265.yaml" />
 

--- a/abb_irb6700_support/launch/robot_state_visualize_irb6700_200_260.launch
+++ b/abb_irb6700_support/launch/robot_state_visualize_irb6700_200_260.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of the state visualizer.
 
   Defaults provided for IRB 6700-200/2.60:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_state_visualize_irb6700_200_260.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6700_support)/config/joint_names_irb6700_200_260.yaml" />
 

--- a/abb_irb6700_support/launch/robot_state_visualize_irb6700_235_265.launch
+++ b/abb_irb6700_support/launch/robot_state_visualize_irb6700_235_265.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of the state visualizer.
 
   Defaults provided for IRB 6700-235/2.65:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_state_visualize_irb6700_235_265.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb6700_support)/config/joint_names_irb6700_235_265.yaml" />
 

--- a/abb_irb7600_support/launch/robot_interface_download_irb7600_150_350.launch
+++ b/abb_irb7600_support/launch/robot_interface_download_irb7600_150_350.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of abb driver's 'robot_interface.launch'.
 
   Defaults provided for IRB 7600-150/3.50:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_interface_download_irb_7600_150_350.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb7600_support)/config/joint_names_irb7600_150_350.yaml" />
 

--- a/abb_irb7600_support/launch/robot_state_visualize_irb7600_150_350.launch
+++ b/abb_irb7600_support/launch/robot_state_visualize_irb7600_150_350.launch
@@ -3,14 +3,14 @@
   Manipulator specific version of the state visualizer.
 
   Defaults provided for IRB 7600-150/3.50:
-   - J23_coupled = true
+   - J23_coupled = false
 
   Usage:
     robot_state_visualize_irb_7600_150_350.launch robot_ip:=<value>
 -->
 <launch>
   <arg name="robot_ip" doc="IP of the controller" />
-  <arg name="J23_coupled" default="true" doc="If true, compensate for J2-J3 parallel linkage" />
+  <arg name="J23_coupled" default="false" doc="If true, compensate for J2-J3 parallel linkage" />
 
   <rosparam command="load" file="$(find abb_irb7600_support)/config/joint_names_irb7600_150_350.yaml" />
 


### PR DESCRIPTION
As per title.

Rebased and updated version of #139.

Commit provenance and attribution retained.

Thanks @cjue for the initial PR.

One additional change merged into 6d992ace118746e65a019b4d75cb097ddd6b81fc: updated the `.launch` files for the 10/1.45 variant to also set the default for `J23_coupled` to `false`.
